### PR TITLE
fix PUBLIC_IP_RESPONSE

### DIFF
--- a/lib/collect_user_inputs.sh
+++ b/lib/collect_user_inputs.sh
@@ -9,7 +9,7 @@ collect_user_inputs() {
     if [[ $REPLY =~ ^[Nn]$ ]]; then
         # Fetch public IP using the Datalayer API
         echo -e "\n${BLUE}Fetching your public IP address...${NC}"
-        PUBLIC_IP_RESPONSE=$(curl -s --max-time 20 --connect-timeout 10 https://api.datalayer.storage/user/v1/get_user_ip | grep -o '"public_ip":[^,]*' | awk -F':' '{gsub(/"/,"",$2); print $2}')
+        PUBLIC_IP_RESPONSE=$(curl -s --max-time 20 --connect-timeout 10 https://api.datalayer.storage/user/v1/get_user_ip | grep -o '"ip_address":[^,]*' | awk -F':' '{gsub(/"/,"",$2); print $2}')
 
         if [[ -z "$PUBLIC_IP_RESPONSE" || "$PUBLIC_IP_RESPONSE" == "null" ]]; then
             echo -e "${RED}Failed to automatically fetch your public IP address.${NC}"


### PR DESCRIPTION
This PR updates the command for extracting the `public IP` address from the dig datalayer API. The `public_ip` field in the response has been replaced with `ip_address`, requiring an update to the curl command to ensure correct parsing.

API Response:
```
~/chia-dig-node# curl -s --max-time 20 --connect-timeout 10 https://api.datalayer.storage/user/v1/get_user_ip
{"ip_address":"45.77.37.98","success":true}
```