### PR TITLE
Update open_ports.sh for enabling ufw 

### DIFF
--- a/lib/open_ports.sh
+++ b/lib/open_ports.sh
@@ -36,6 +36,7 @@ open_ports() {
     # Use the appropriate firewall management tool based on the distribution
     case $FIREWALL in
         ufw)
+            yes | ufw enable
             for PORT in "${PORTS[@]}"; do
                 echo -e "${YELLOW}Allowing port $PORT on UFW...${NC}"
                 ufw allow "$PORT"


### PR DESCRIPTION
Currently the script makes the assumption that ufw is enabled, it's not enabled by default on a fresh ubuntu 24.04 server install. Enabling of ufw firewall otherwise the rules are not applied and the firewall not reloaded.